### PR TITLE
Remove extra closing parenthesis

### DIFF
--- a/08-in-practice-project-collage/projects/starter/CollageNeue/Model/CollageNeueModel.swift
+++ b/08-in-practice-project-collage/projects/starter/CollageNeue/Model/CollageNeueModel.swift
@@ -94,6 +94,6 @@ class CollageNeueModel: ObservableObject {
       }
       
       // Send the selected image
-    })
+    }
   }
 }


### PR DESCRIPTION
In last changes in https://github.com/raywenderlich/comb-materials/commit/b60182359778e307f2b48d57182eafd090082b31 you forgot to remove one closing parenthesis when moved `resultHandler` closure from arguments to trailing closure in `requestImage` call. 
Project can not be build becouse of that.